### PR TITLE
[fix]: fixed typo on warning about compute prices

### DIFF
--- a/guides/computes.mdx
+++ b/guides/computes.mdx
@@ -39,7 +39,7 @@ First, Click **New Compute**. You will be redirected to a Create nee SC compute 
  <Frame>
       <img src="/images/computes/create-compute.png" style={{ borderRadius: "0.2rem" }} />
     </Frame>
-<Warning>Remember to copy and paste the nameservers provided to you to you domain provider, otherwise the domain you will create will be inactive until you do so.</Warning>
+<Warning>Remember that the **accumulated cost of your compute depends on the specs you selected**, alongside the specification you will find the amount/price of the compute</Warning>
 
 ## Computes monitoring
 


### PR DESCRIPTION
This PR fixes an identified typo on the warning about prices for compute and selected specifications