### PR TITLE
[fix]: added section id to identify the changelog redirect url from the platform

### DIFF
--- a/.github/scripts/notify-backend.js
+++ b/.github/scripts/notify-backend.js
@@ -5,6 +5,7 @@ const summary = process.env.RELEASE_SUMMARY;
 const versionTag = process.env.VERSION_TAG;
 const title = process.env.RELEASE_TITLE;
 const imageUrl = process.env.RELEASE_IMAGE_URL;
+const section_id=process.env.SECTION_ID;
 const apiToken = process.env.BACKEND_API_SECRET;
 const environment = process.env.ENVIRONMENT || 'production';
 
@@ -35,6 +36,7 @@ const requestBody = JSON.stringify({
   tag: versionTag,
   title: title,
   imageUrl: imageUrl,
+  sectionID: section_id,
   timestamp: new Date().toISOString()
 });
 

--- a/.github/workflows/changelog-notify.yml
+++ b/.github/workflows/changelog-notify.yml
@@ -23,6 +23,10 @@ on:
         description: 'The image url, short url of the release to be sent to the API.'
         required: true
         default: 'https//'
+      section_id:
+        description: 'The unique identifier of the changelog section pointing to that weeks updates'
+        required: true
+        default: 'week-of-october-21-27,-2025'
       tag:
         description: 'The tag (e.g., Feature, Fix) associated with this release.'
         required: true
@@ -47,5 +51,6 @@ jobs:
           RELEASE_SUMMARY: ${{ github.event.inputs.release_summary }}
           RELEASE_TITLE: ${{ github.event.inputs.release_title }}
           RELEASE_IMAGE_URL: ${{ github.event.inputs.release_image_url }}
+          SECTION_ID: ${{ github.event.inputs.section_id }}
           VERSION_TAG: ${{ github.event.inputs.tag }}
           BACKEND_API_SECRET: ${{ secrets.CHANGELOG_API_SECRET }}


### PR DESCRIPTION
This PR adds a section id field to uniquely identify which group a release belongs to on the changelog documentation page