### PR TITLE
feat: restructure AI skill for skills.sh and Agent Skills spec

### DIFF
--- a/api-reference/ai-skill.mdx
+++ b/api-reference/ai-skill.mdx
@@ -6,14 +6,24 @@ icon: 'wand-magic-sparkles'
 
 Give your AI coding assistant complete knowledge of the Strettch Cloud API so it can help you integrate in one shot.
 
-<Card title="Download skill file" icon="download" href="https://raw.githubusercontent.com/strettch/cloud-docs/main/strettch-cloud-skill.md">
+## Install via skills.sh
+
+The fastest way for any [skills.sh](https://skills.sh)-compatible agent (Claude Code, Cursor, Codex, OpenCode, Goose, and more):
+
+```bash
+npx skills add strettch/cloud-docs
+```
+
+## Download manually
+
+<Card title="Download SKILL.md" icon="download" href="https://raw.githubusercontent.com/strettch/cloud-docs/main/skills/strettch-cloud/SKILL.md">
   Paste the contents into your AI assistant's context or system prompt.
 </Card>
 
 ```bash
-curl -O https://raw.githubusercontent.com/strettch/cloud-docs/main/strettch-cloud-skill.md
+curl -O https://raw.githubusercontent.com/strettch/cloud-docs/main/skills/strettch-cloud/SKILL.md
 ```
 
 <Note>
-  Works with Claude Code, ChatGPT, Cursor, Windsurf, Copilot, and any AI tool that accepts context files. Download and paste the contents into your assistant's context or system prompt.
+  Compatible with any AI tool that supports the [Agent Skills](https://agentskills.io) format or accepts context files.
 </Note>

--- a/skills/strettch-cloud/SKILL.md
+++ b/skills/strettch-cloud/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: strettch-cloud
+description: Provision and manage Strettch Cloud compute instances via the Public API. Use when the user wants to create, list, start, stop, reboot, upsize, or delete cloud servers, or when they mention Strettch Cloud, KGL-1, or api.strettch.cloud.
+license: Apache-2.0
+metadata:
+  author: strettch
+  version: "1.0"
+---
+
 # Strettch Cloud API Skill
 
 A skill that gives AI full context on how to use the Strettch Cloud Public API to provision and manage compute instances.

--- a/skills/strettch-cloud/SKILL.md
+++ b/skills/strettch-cloud/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: strettch-cloud
-description: Provision and manage Strettch Cloud compute instances via the Public API. Use when the user wants to create, list, start, stop, reboot, upsize, or delete cloud servers, or when they mention Strettch Cloud, KGL-1, or api.strettch.cloud.
-license: Apache-2.0
-metadata:
-  author: strettch
-  version: "1.0"
+description: Provision and manage compute instances on Strettch Cloud via the Public API. Use when the user mentions Strettch, strettch.cloud, api.strettch.cloud, KGL-1, Kigali cloud infrastructure, or needs to create, start, stop, reboot, upsize, or delete cloud compute instances through the Strettch REST API.
 ---
 
 # Strettch Cloud API Skill


### PR DESCRIPTION
Move strettch-cloud-skill.md to skills/strettch-cloud/SKILL.md with required YAML frontmatter, and add the npx skills add install command to the docs page. The skill is now installable via any skills.sh- compatible agent.