### PR TITLE
chore: integrate polin-guard for commit payload scanning

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# polin-guard — block obfuscated/injected payloads from entering the repo.
+#
+# Enable locally:  git config core.hooksPath .githooks
+# (Node repos enable this automatically via the "prepare" script on install.)
+if ! command -v npx >/dev/null 2>&1; then
+  echo "polin-guard: Node/npx not found — skipping local scan (CI still enforces it)." >&2
+  exit 0
+fi
+exec npx --yes polin-guard@0.3.2 --staged

--- a/.github/workflows/polin-guard.yml
+++ b/.github/workflows/polin-guard.yml
@@ -1,0 +1,22 @@
+name: polin-guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for injected payloads
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Repository Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # polin-guard --ci needs full history to see all tracked files
+
+      - name: Scan for injected payloads (polin-guard)
+        run: npx --yes polin-guard@0.3.2 --ci


### PR DESCRIPTION
## What

Integrates [polin-guard](https://www.npmjs.com/package/polin-guard) — a zero-dependency scanner that blocks obfuscated / injected build-time code payloads (hidden long-line JS stagers) before they enter the repo. This mirrors the rollout already landed in `strettch-cloud` ([35ad8fd](https://github.com/strettch/strettch-cloud/commit/35ad8fd578f64d9933f6f89e943925d3994a1879)).

## Changes

- **CI** — Added a new `.github/workflows/polin-guard.yml` (no PR-validation workflow existed). It runs `npx --yes polin-guard@0.3.2 --ci` on pull requests and pushes, scanning every git-tracked file and **failing only on critical (blocking) findings**.
- **Pre-commit** — `.githooks/pre-commit` runs `npx --yes polin-guard@0.3.2 --staged` on staged content. The hook no-ops gracefully if Node/npx isn't on PATH, so CI remains the source of truth.

## Enabling the pre-commit hook locally

No package.json here, so enable it once with: `git config core.hooksPath .githooks`

## Verification

Ran `polin-guard --ci` against the full tree on this branch — **no blocking findings** (clean baseline). Version pinned to `0.3.2` (npm versions are immutable, so the pin is reproducible).

> Note: commits are unsigned — the signing key wasn't available in the environment used to prepare this PR. Re-sign/amend if branch protection requires verified commits.
