### PR TITLE
feat: add section_id input to changelog notify workflow

### DIFF
--- a/.github/workflows/changelog-notify.yml
+++ b/.github/workflows/changelog-notify.yml
@@ -23,6 +23,9 @@ on:
         description: 'Release Preview (Image / Gif)'
         required: true
         default: 'https//example.com/image-preview.webp'
+      section_id:
+        description: 'Section ID i.e "team-creation" or "/team-creation"'
+        required: true
       tag:
         description: 'Release Category'
         required: true


### PR DESCRIPTION
Define section_id as a required workflow_dispatch input so it is collected on dispatch and forwarded to the backend via SECTION_ID.